### PR TITLE
fix for jQuery

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -29,7 +29,7 @@
 
   <script type='text/javascript' defer src='{{ "/assets/bootstrap/bootstrap.min.js" | absolute_url }}'></script>
 
-  <script type='text/javascript' defer src='{{ "/assets/js/jquery-3.5.1.min.js" | absolute_url }}'></script>
+  <script type='text/javascript' src='{{ "/assets/js/jquery-3.5.1.min.js" | absolute_url }}'></script>
 
   <noscript><p>Please enable JavaScript in your browser.</p></noscript>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,12 +21,4 @@
 
   </body>
 
-  {% if page.gallery %}
-  <script type='text/javascript' async defer src='{{ "/assets/js/facets.js" | absolute_url }}'></script>
-  {% endif %}
-  
-  <script type='text/javascript' async defer src='{{ "/assets/bootstrap/bootstrap.min.js" | absolute_url }}'></script>
-  <!--script type='text/javascript' async defer src='{{ "/assets/popper.min.js" | absolute_url }}'></script-->
 </html>
-
-


### PR DESCRIPTION
Hi @elotroalex ! I got jQuery to work just by removing `defer`. I think `defer` starts page parsing right away, so it finds the inline JS before jQuery has a chance to load. On my machine, the jQuery error goes away and the filters still seem to work fine.  (This also might explain why you weren't seeing the error - maybe jQuery loaded faster for you, so it was available in time for the inline JS?)

If that fix sounds okay to you, feel free to merge. If that's not appropriate, though, maybe there's a better fix. 

will fix #35 